### PR TITLE
Xh m188

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ zip: build
 
 build: words
 	make BOARD=CORE
+	make BOARD=XH-M188
 	make BOARD=W1209
 	make BOARD=W1219
 	make BOARD=W1401

--- a/XH-M188/boardcore.inc
+++ b/XH-M188/boardcore.inc
@@ -111,6 +111,7 @@ BKEYCHAR:
 
 ; PWM! ( pwm -- ) 
 ; Set PWM duty cycle
+; Max seems to be around 3300 (3583 is full on)
 	.dw    LINK
 
 	LINK =  .
@@ -119,6 +120,5 @@ BKEYCHAR:
 PWMSET:
         DoLitW  TIM1_CCR1H
         JP      DCSTOR
-	RET
 
 

--- a/XH-M188/boardcore.inc
+++ b/XH-M188/boardcore.inc
@@ -1,13 +1,38 @@
-; STM8S003F3P6 "Core" STM8S device dependent routine default code
+; STM8S003F3P6 XH-M188 STM8S device dependent routine default code
 
 ; Note: for supporting a new board create a new board configuration
 ;       folder with a "globconfig.inc" and a copy of this file.
 
 ;       BOARDINIT  ( -- )
 ;       Init board GPIO (except COM ports)
+;       IO on this board is unfettered when LED display is pulled
+;       Buttons: Minus PB4, Plus PB5, On/Off PC4  -- default is input
+;       PWM Voltage Control: PC6, Timer 1, Channel 1
 
 BOARDINIT:
         ; Board I/O initialization
+	; Init Timer for PWM
+	; Unlock EEPROM and set AFR0 flag
+        CALL    ULOCK
+        MOV     FLASH_CR2, #0b10000000
+        MOV     FLASH_NCR2,#0b01111111
+	MOV     OPT2, #0b00000001
+	MOV     NOPT2,#0b11111110
+; should wait for EOP bit here...meh, seems to work
+; then re-lock
+        MOV     FLASH_CR2, #0b00000000
+        MOV     FLASH_NCR2,#0b11111111
+	CALL LOCK
+
+	; Set voltage-control PWM timers
+        MOV     TIM1_ARRH,#0x0D ; approx 4.5 kHz
+        MOV     TIM1_ARRL,#0xFF 
+        MOV     TIM1_CCR1H,#0x00 ; Start PWM off
+        MOV     TIM1_CCR1L,#0x00 
+        MOV     TIM1_CCER1,#0x01 ; output on chan 1 
+        MOV     TIM1_CCMR1,#0x60 ; count-up mode
+        MOV     TIM1_BKR,#0b10000000 ; output enable
+	MOV     TIM1_CR1,#0b00000001 ; enable timer
 
         RET
 
@@ -81,4 +106,19 @@ BKEY:
 BKEYCHAR:
         JRA     BKEY            ; Dummy: get "no key" and leave it as it is
        .endif
+
+; ============================================================
+
+; PWM! ( pwm -- ) 
+; Set PWM duty cycle
+	.dw    LINK
+
+	LINK =  .
+        .db     (4)
+        .ascii  "PWM!"
+PWMSET:
+        DoLitW  TIM1_CCR1H
+        JP      DCSTOR
+	RET
+
 

--- a/XH-M188/boardcore.inc
+++ b/XH-M188/boardcore.inc
@@ -60,53 +60,6 @@ _EXTI2_IRQHandler:
 _EXTI3_IRQHandler:
         .endif
 
-
-; ==============================================
-
-        .ifne   HAS_LED7SEG
-;       LED_MPX driver ( -- )
-;       Code called from ISR for LED MPX
-
-LED_MPX:
-        RET
-        .endif
-
-; ==============================================
-
-        .ifne   HAS_OUTPUTS
-;       OUT!  ( c -- )
-;       Put c to board outputs, storing a copy in OUTPUTS
-        .dw     LINK
-
-        LINK =  .
-        .db     (4)
-        .ascii  "OUT!"
-OUTSTOR:
-        RET
-        .endif
-
-;===============================================================
-
-        .ifne   HAS_KEYS
-;       BKEY  ( -- f )     ( TOS STM8: -- A,Z,N )
-;       Read board key state as a bitfield
-        .dw     LINK
-
-        LINK =  .
-        .db     (4)
-        .ascii  "BKEY"
-BKEY:
-        CLR     A
-        JP      ASTOR
-
-
-;       BKEYC  (  -- c )   ( TOS STM8: -- A,Z,N )
-;       Read and translate board dependent key bitmap into char
-
-BKEYCHAR:
-        JRA     BKEY            ; Dummy: get "no key" and leave it as it is
-       .endif
-
 ; ============================================================
 
 ; PWM! ( pwm -- ) 

--- a/XH-M188/boardcore.inc
+++ b/XH-M188/boardcore.inc
@@ -60,6 +60,38 @@ _EXTI2_IRQHandler:
 _EXTI3_IRQHandler:
         .endif
 
+;===============================================================
+
+        .ifne   HAS_KEYS
+;       BKEY  ( -- c )     ( TOS STM8: -- A,Z,N )
+;       Read board key state as a bitfield
+        .dw     LINK
+
+        LINK =  .
+        .db     (4)
+        .ascii  "BKEY"
+BKEY:
+        ; Keys "minus" (1), "plus" (2), "on/off" (4)
+        CLR     A
+        BTJT    PB_IDR,#4,1$    ; test "minus"
+        OR      A,#0x01
+1$:     BTJT    PB_IDR,#5,2$    ; test "plus"
+        OR      A,#0x02
+2$:     BTJT    PC_IDR,#4,3$    ; test "on/off"
+        OR      A,#0x04
+3$:     JP      ASTOR
+
+;       BKEYC  ( -- c )   ( TOS STM8: -- A,Z,N )
+;       Read and translate board dependent key bitmap into char
+
+BKEYCHAR:
+        CALLR   BKEY
+        JREQ    1$
+        ADD     A,#'@'
+        LD      (1,X),A
+1$:     RET
+       .endif
+
 ; ============================================================
 
 ; PWM! ( pwm -- ) 

--- a/XH-M188/boardcore.inc
+++ b/XH-M188/boardcore.inc
@@ -1,0 +1,84 @@
+; STM8S003F3P6 "Core" STM8S device dependent routine default code
+
+; Note: for supporting a new board create a new board configuration
+;       folder with a "globconfig.inc" and a copy of this file.
+
+;       BOARDINIT  ( -- )
+;       Init board GPIO (except COM ports)
+
+BOARDINIT:
+        ; Board I/O initialization
+
+        RET
+
+;===============================================================
+
+;      Dummy labels for PSIM interrupts declared in main.c
+
+        .ifne   PSIM-PORTA
+;       Dummy label for _EXTIA_IRQHandler
+_EXTI0_IRQHandler:
+        .endif
+
+        .ifne   PSIM-PORTB
+;       Dummy label for _EXTIB_IRQHandler
+_EXTI1_IRQHandler:
+        .endif
+
+        .ifne   PSIM-PORTC
+;       Dummy label for _EXTIC_IRQHandler
+_EXTI2_IRQHandler:
+        .endif
+
+        .ifne   PSIM-PORTD
+;       Dummy label for _EXTID_IRQHandler
+_EXTI3_IRQHandler:
+        .endif
+
+
+; ==============================================
+
+        .ifne   HAS_LED7SEG
+;       LED_MPX driver ( -- )
+;       Code called from ISR for LED MPX
+
+LED_MPX:
+        RET
+        .endif
+
+; ==============================================
+
+        .ifne   HAS_OUTPUTS
+;       OUT!  ( c -- )
+;       Put c to board outputs, storing a copy in OUTPUTS
+        .dw     LINK
+
+        LINK =  .
+        .db     (4)
+        .ascii  "OUT!"
+OUTSTOR:
+        RET
+        .endif
+
+;===============================================================
+
+        .ifne   HAS_KEYS
+;       BKEY  ( -- f )     ( TOS STM8: -- A,Z,N )
+;       Read board key state as a bitfield
+        .dw     LINK
+
+        LINK =  .
+        .db     (4)
+        .ascii  "BKEY"
+BKEY:
+        CLR     A
+        JP      ASTOR
+
+
+;       BKEYC  (  -- c )   ( TOS STM8: -- A,Z,N )
+;       Read and translate board dependent key bitmap into char
+
+BKEYCHAR:
+        JRA     BKEY            ; Dummy: get "no key" and leave it as it is
+       .endif
+

--- a/XH-M188/globconf.inc
+++ b/XH-M188/globconf.inc
@@ -2,8 +2,8 @@
 ; Config for XH-M188 Board
 ; Clock: HSI (no crystal)
 
-        HAS_KEYS         = 3    ; yes, 3 keys on module
-        HAS_OUTPUTS      = 1    ; yes, one LED
+        HAS_KEYS         = 0    ; yes, 3 keys on module
+        HAS_OUTPUTS      = 0    ; yes, one LED
         HAS_ADC          = 1    ; Analog input words
 
         HAS_BACKGROUND   = 1    ; Background Forth task (TIM2 ticker)
@@ -18,13 +18,13 @@
         WORDS_LINKINTER  = 0    ; Link interpreter words: ACCEPT QUERY TAP kTAP hi 'BOOT tmp >IN 'TIB #TIB eval CONTEXT pars PARSE NUMBER? DIGIT? WORD TOKEN NAME> SAME? find ABORT aborq $INTERPRET INTER? .OK ?STACK EVAL PRESET QUIT $COMPILE
         WORDS_LINKCOMP   = 0    ; Link compiler words: cp last OVERT $"| ."| $,n
         WORDS_LINKRUNTI  = 0    ; Link runtime words: doLit do$ doVAR donxt dodoes ?branch branch
-        WORDS_LINKCHAR   = 0    ; Link char out words: DIGIT <# # #S SIGN #> str hld HOLD
+        WORDS_LINKCHAR   = 1    ; Link char out words: DIGIT <# # #S SIGN #> str hld HOLD
         WORDS_LINKMISC   = 0    ; Link composing words of SEE DUMP WORDS: >CHAR _TYPE dm+ .ID >NAME
 
-        WORDS_EXTRASTACK = 1    ; Link/include stack core words: rp@ rp! sp! sp@ DEPTH
+        WORDS_EXTRASTACK = 0    ; Link/include stack core words: rp@ rp! sp! sp@ DEPTH
         WORDS_EXTRADEBUG = 0    ; Extra debug words: SEE
         WORDS_EXTRACORE  = 1    ; Extra core words: =0 I
         WORDS_EXTRAMEM   = 1    ; Extra memory words: B! 2C@ 2C!
         WORDS_EXTRAEEPR  = 1    ; Extra EEPROM lock/unlock words: LOCK ULOCK ULOCKF LOCKF
-        WORDS_HWREG      = 1    ; Peripheral Register words
+        WORDS_HWREG      = 0    ; Peripheral Register words
 

--- a/XH-M188/globconf.inc
+++ b/XH-M188/globconf.inc
@@ -26,5 +26,5 @@
         WORDS_EXTRACORE  = 1    ; Extra core words: =0 I
         WORDS_EXTRAMEM   = 1    ; Extra memory words: B! 2C@ 2C!
         WORDS_EXTRAEEPR  = 1    ; Extra EEPROM lock/unlock words: LOCK ULOCK ULOCKF LOCKF
-        WORDS_HWREG      = 0    ; Peripheral Register words
+        WORDS_HWREG      = 1    ; Peripheral Register words
 

--- a/XH-M188/globconf.inc
+++ b/XH-M188/globconf.inc
@@ -22,7 +22,7 @@
         WORDS_LINKMISC   = 0    ; Link composing words of SEE DUMP WORDS: >CHAR _TYPE dm+ .ID >NAME
 
         WORDS_EXTRASTACK = 1    ; Link/include stack core words: rp@ rp! sp! sp@ DEPTH
-        WORDS_EXTRADEBUG = 1    ; Extra debug words: SEE
+        WORDS_EXTRADEBUG = 0    ; Extra debug words: SEE
         WORDS_EXTRACORE  = 1    ; Extra core words: =0 I
         WORDS_EXTRAMEM   = 1    ; Extra memory words: B! 2C@ 2C!
         WORDS_EXTRAEEPR  = 1    ; Extra EEPROM lock/unlock words: LOCK ULOCK ULOCKF LOCKF

--- a/XH-M188/globconf.inc
+++ b/XH-M188/globconf.inc
@@ -2,8 +2,8 @@
 ; Config for XH-M188 Board
 ; Clock: HSI (no crystal)
 
-        HAS_KEYS         = 0    ; yes, 3 keys on module
-        HAS_OUTPUTS      = 0    ; yes, one LED
+        HAS_KEYS         = 3    ; yes, 3 keys on module
+        HAS_OUTPUTS      = 0    ; nope
         HAS_ADC          = 1    ; Analog input words
 
         HAS_BACKGROUND   = 1    ; Background Forth task (TIM2 ticker)

--- a/XH-M188/globconf.inc
+++ b/XH-M188/globconf.inc
@@ -1,7 +1,30 @@
 ; STM8EF Global Configuration File
-; Minimal config for STM8S Value Line, defaults with few extras (e.g. NVM)
+; Config for XH-M188 Board
+; Clock: HSI (no crystal)
 
+        HAS_KEYS         = 3    ; yes, 3 keys on module
+        HAS_OUTPUTS      = 1    ; yes, one LED
+        HAS_ADC          = 1    ; Analog input words
+
+        HAS_BACKGROUND   = 1    ; Background Forth task (TIM2 ticker)
         HAS_CPNVM        = 1    ; Can compile to Flash, always interpret to RAM
-        BAREBONES        = 1    ; Remove or unlink some more: hi HERE .R U.R SPACES @EXECUTE AHEAD CALL, EXIT COMPILE [COMPILE]
+        HAS_DOES         = 1    ; CREATE-DOES> extension
+        HAS_DOLOOP       = 1    ; DO .. LOOP extension: DO LEAVE LOOP +LOOP
+
+        CASEINSENSITIVE  = 1    ; Case insensitive dictionary search
+        SPEEDOVERSIZE    = 0    ; Speed-over-size in core words: ROT - = <
+        BAREBONES        = 0    ; Remove or unlink some more: hi HERE .R U.R SPACES @EXECUTE AHEAD CALL, EXIT COMPILE [COMPILE]
+
+        WORDS_LINKINTER  = 0    ; Link interpreter words: ACCEPT QUERY TAP kTAP hi 'BOOT tmp >IN 'TIB #TIB eval CONTEXT pars PARSE NUMBER? DIGIT? WORD TOKEN NAME> SAME? find ABORT aborq $INTERPRET INTER? .OK ?STACK EVAL PRESET QUIT $COMPILE
+        WORDS_LINKCOMP   = 0    ; Link compiler words: cp last OVERT $"| ."| $,n
+        WORDS_LINKRUNTI  = 0    ; Link runtime words: doLit do$ doVAR donxt dodoes ?branch branch
+        WORDS_LINKCHAR   = 0    ; Link char out words: DIGIT <# # #S SIGN #> str hld HOLD
+        WORDS_LINKMISC   = 0    ; Link composing words of SEE DUMP WORDS: >CHAR _TYPE dm+ .ID >NAME
+
+        WORDS_EXTRASTACK = 1    ; Link/include stack core words: rp@ rp! sp! sp@ DEPTH
+        WORDS_EXTRADEBUG = 1    ; Extra debug words: SEE
         WORDS_EXTRACORE  = 1    ; Extra core words: =0 I
+        WORDS_EXTRAMEM   = 1    ; Extra memory words: B! 2C@ 2C!
+        WORDS_EXTRAEEPR  = 1    ; Extra EEPROM lock/unlock words: LOCK ULOCK ULOCKF LOCKF
+        WORDS_HWREG      = 1    ; Peripheral Register words
 

--- a/XH-M188/globconf.inc
+++ b/XH-M188/globconf.inc
@@ -1,0 +1,7 @@
+; STM8EF Global Configuration File
+; Minimal config for STM8S Value Line, defaults with few extras (e.g. NVM)
+
+        HAS_CPNVM        = 1    ; Can compile to Flash, always interpret to RAM
+        BAREBONES        = 1    ; Remove or unlink some more: hi HERE .R U.R SPACES @EXECUTE AHEAD CALL, EXIT COMPILE [COMPILE]
+        WORDS_EXTRACORE  = 1    ; Extra core words: =0 I
+

--- a/XH-M188/target.inc
+++ b/XH-M188/target.inc
@@ -1,0 +1,14 @@
+;       STM8S103F3 device and memory layout configuration
+
+        TARGET = STM8S103F3
+
+        RAMEND =        0x03FF  ; system (return) stack, growing down
+        EEPROMEND =     0x427F  ; STM8S103F3: 640 bytes EEPROM
+        FLASHEND =      0x9FFF  ; 8K devices
+
+        FORTHRAM =      0x0040  ; Start of RAM controlled by Forth
+        UPPLOC  =       0x0060  ; UPP (user/system area) location for 1K RAM
+        CTOPLOC =       0x0080  ; CTOP (user dictionary) location for 1K RAM
+        SPPLOC  =       0x0350  ; SPP (data stack top), TIB start
+        RPPLOC  =       RAMEND  ; RPP (return stack top)
+

--- a/forth.asm
+++ b/forth.asm
@@ -5392,9 +5392,9 @@ RESTC:
 
 
         .ifne WORDS_HWREG
-        .ifne (TARGET - STM8S103F3)
+;        .ifne (TARGET - STM8S103F3)
           .include "hwregs8s003.inc"
-        .endif
+;        .endif
         .endif
 
 

--- a/stm8device.inc
+++ b/stm8device.inc
@@ -19,6 +19,11 @@ PORTX        = 0
         CR1          = 3
         CR2          = 4
 
+; ***** Option Bytes in EEPROM
+
+        OPT2         = 0x4803   ; Alternate Function Mapping            (0x00)
+        NOPT2        = 0x4804   ; Alternate Function Mapping            (0xFF)
+
 ; ***** Port A
 
         PA_ODR       = 0x5000   ; Port A data output latch register     (0x00)


### PR DESCRIPTION
Hiya Thomas,

Here is the init code for PWM.  It works fine for setting the voltage.  I added a primitive PWM! command that sets the value, if you want to check it out.  Useful range is 0-3300 or so, depending on input voltage.  

I have a slight qualm about the init routine -- in the middle it should delay or loop until a bit is set, but my assembly skills aren't up to the task just yet.  (See the boardcore.inc for my notes in progress.)

I'm going to write some KEYS functions in the same style as yours on the DCDC board (for instance), and then maybe circle back.

Anyway, here's a pull just to get the ball rolling.  Next are inputs.
