### PR TITLE
Automated build in Travis CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
-temp/
 test/
 out/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+dist: trusty
+language: c
+sudo: required
+env:
+  - BOARD=CORE
+  - BOARD=MINDEV
+install: sh -e test/deps.sh
+script: make BOARD=$BOARD

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # STM8S eForth (stm8ef)
 
+[![Test](https://travis-ci.org/TG9541/stm8ef.svg)](https://travis-ci.org/TG9541/stm8ef)
+
 TG9541/STM8EF is based on [Dr. C.H. Ting's eForth for the *STM8S Discovery*](http://www.forth.org/svfig/kk/07-2010.html). It aims to be a lightweight embedded "untethered" (self-hosted) Forth system for low-end STM8 µCs with a maximum "feature-to-binary-size" ratio. It provides a plug-in system for board support, base dictionary configuration, a Forth include file infrastructure, and uCsim based binary level simulation. With the kind permission of the original author, TG9541/STM8EF has a permissive [FOSS license](https://github.com/TG9541/stm8ef/blob/master/LICENSE.md).
 
 The [Wiki on GitHub](https://github.com/TG9541/stm8ef/wiki) covers various topics, e.g. how to use cheap Chinese thermostats, voltmeters, or DC/DC-converters, as Forth powered embedded control boards.

--- a/test/deps.sh
+++ b/test/deps.sh
@@ -1,0 +1,6 @@
+sudo apt-get install subversion libboost-dev texinfo
+svn checkout svn://svn.code.sf.net/p/sdcc/code/trunk/sdcc sdcc
+cd sdcc
+./configure --disable-pic14-port --disable-pic16-port
+make
+sudo make install


### PR DESCRIPTION
Hello,

This adds an automated build.  To work, you must login to Travis CI and enable builds for this repository.

At this point, two boards are built: CORE, and MINDEV.  More could be added.

There could also be an automated test using uCsim, but I'm not sure if there's anything suitable as of now.