### PR TITLE
Make Travis cache the SDCC binaries between builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,8 @@ env:
   - BOARD=CORE
   - BOARD=MINDEV
   - BOARD=SWIMCOM
+cache:
+  directories:
+    - $HOME/sdcc
 install: sh -e test/deps.sh
-script: make BOARD=$BOARD
+script: PATH=$PATH:$HOME/sdcc/bin make BOARD=$BOARD

--- a/test/deps.sh
+++ b/test/deps.sh
@@ -1,6 +1,8 @@
+test -f $HOME/sdcc/bin/sdasstm8 && exit 0
+
 sudo apt-get install subversion libboost-dev texinfo
 svn checkout svn://svn.code.sf.net/p/sdcc/code/trunk/sdcc sdcc
 cd sdcc
-./configure --disable-pic14-port --disable-pic16-port
+./configure --disable-pic14-port --disable-pic16-port --prefix=$HOME/sdcc
 make
 sudo make install


### PR DESCRIPTION
This brings the Travis builds down from six minutes to 30 seconds.