### PR TITLE
Update CONSTANT

### DIFF
--- a/lib/CONSTANT
+++ b/lib/CONSTANT
@@ -31,7 +31,7 @@
 
  MARKER RAM\
 
-\res MCU: mcu/STM8S103
+\res MCU: STM8S103
 \res export PB_ODR
 
  NVM

--- a/lib/CONSTANT
+++ b/lib/CONSTANT
@@ -21,7 +21,9 @@
   NVM
 
   : CONSTANT ( "name" x -- )
-    : compile docon , [compile] [ overt immediate ; 
+    : compile docon , [compile] [ overt immediate ;
+    
+  RAM
 
   RAM\
 \ ------------------------------------------------------------------------------
@@ -29,13 +31,15 @@
 
  MARKER RAM\
 
-\res MCU: STM8S103
+\res MCU: mcu/STM8S103
 \res export PB_ODR
 
  NVM
 
   : LED.on ( -- )  0 PB_ODR 5 B! ;
   : LED.off ( -- ) 1 PB_ODR 5 B! ;
+  
+ RAM
 
  RAM\
 


### PR DESCRIPTION
Hi Thomas

I think you should switch back from NVM to RAM.
If STM8S103.efr is put in lib/mcu the directive in the example should point to mcu/STM8S103. Or can one make e4thcom to search recursive?