### PR TITLE
CURRENT add-on, VOC, and VOCABULARY for STM8 eForth by Manfred Mahlow

### DIFF
--- a/lib/?RAM
+++ b/lib/?RAM
@@ -1,0 +1,8 @@
+\ stm8ef: ?RAM                                                         MM-171128
+\ License see github.com/TG9541/stm8ef/blob/master/LICENSE.md
+
+NVM
+\ Switch to RAM mode if a is an address in the RAM dictionary.
+  : ?RAM ( a -- ) $8000 U< IF RAM THEN ;
+RAM
+

--- a/lib/CURRENT
+++ b/lib/CURRENT
@@ -1,0 +1,249 @@
+\ stm8ef : CURRENT                                                     MM-171114
+\
+\               Copyright (C) 2017 manfred.mahlow@forth-ev.de
+\
+\        License see github.com/TG9541/stm8ef/blob/master/LICENSE.md
+\
+\ This is a patch for the STM8S eForth that adds support for context switching 
+\ as it is required for wordlists (see WORDLIST), vocabularies (see VOCABULARY)
+\ and vocabulary prefixing (see VOC).
+\
+\ This code adds the context/wordlist pointer CURRENT, redefines the context
+\ pointer CONTEXT, makes WORDS, find and NAME? context sensitive and makes
+\ ?UNIQUE search the CURRENT not the CONTEXT wordlist.
+\
+\ Load this patch only once with #require CURRENT and please be aware that the
+\ modifications are made persistent and can only be removed by re-flashing the
+\ MCU.
+\
+\ The patch was tested with CORE.ihx and MINDEV.ihx. It uses ~ 340 bytes of NVM
+\ and 8 bytes in data RAM.
+\
+\ Glossary:
+\
+\   CONTEXT ( -- a )  Points to the top of the actual search order, e.g. to the
+\                     wordlist that is searched first. The default search order
+\                     is FORTH FORTH.
+\
+\   CURRENT ( -- a )  Points to the current compiler context, e.g. to the
+\                     wordlist new words are assigned to. Default is FORTH.
+\
+\   WORDS ( -- )      Displays all words of the CONTEXT wordlist, e.g. of the
+\                     top wordlist in the search order.
+\
+\ The curious can find some implementation notes at the end of this file.
+\ ------------------------------------------------------------------------------
+\ requires stm8ef > 2.2.19
+
+#require WIPE
+
+RAM WIPE
+
+#require MARKER
+#require ALIAS
+#require :NVM
+
+#require ULOCKF
+#require LOCKF
+
+RAM  VARIABLE size  NVM  HERE size !
+
+\ Return true if the word with name address na is a member of the wordlist wid.
+\ id? ( wid na -- f )
+  :NVM
+    DUP C@ $20 AND 
+    IF    \ tagged word
+      4 - @  ( wid tag )
+    ELSE  \ untagged word
+      DROP 0  ( wid wid.FORTH )
+    THEN
+    =
+  ;RAM ALIAS id?
+
+
+RAM MARKER <search-wordlist>  \ Making FIND context sensitive :
+
+#require CONTEXT
+#require find
+
+  \ search-wordlist ( a wid -- xt na | a ff )
+  :NVM
+    >R CONTEXT   \ stm8ef CONTEXT 
+    BEGIN ( a va )
+      OVER SWAP ( a a va ) find DUP 0= IF NIP R> DROP EXIT THEN
+      ( a xt na ) R@ OVER ( a xt na wid na ) id? ( a xt na f )
+      IF ROT R> 2DROP ( xt na ) EXIT THEN
+      ( a xt na )
+      NIP 2-
+    AGAIN
+  ;RAM ALIAS search-wordlist
+
+NVM : find ( a va -- xt na | a f )
+      @ ( wid/ctag)
+      \ ."   find: wid =" dup .   \ only for debugging
+      search-wordlist
+    ;
+
+<search-wordlist>
+
+
+NVM VARIABLE CONTEXT   2 ALLOT   0 0 CONTEXT !   \ hides the stm8ef CONTEXT !
+    VARIABLE CURRENT   0 CURRENT !
+
+
+RAM MARKER <NAME?>  \ Patching NAME? to use the new context sensitive FIND :
+
+#require NAME?
+
+  :NVM ( a va -- xt na | a f )
+  \ search in only one vocabulary
+    \ CONTEXT find R> DROP
+  \ search in two vocabularies
+    CONTEXT find ?DUP 0= IF [ CONTEXT 2+ ] LITERAL find THEN R> DROP
+  ;RAM ' NAME? 1+ ULOCKF ! LOCKF  \ patching
+
+<NAME?>
+
+
+RAM MARKER <?UNIQUE>  \ Patching ?UNIQUE to only search the CURRENT wordlist :
+
+#require ?UNIQUE
+
+  :NVM ( a va -- xt na | a f )
+    CURRENT find
+  ;RAM ' ?UNIQUE 4 + ULOCKF ! LOCKF  \ patching
+
+<?UNIQUE>
+
+
+RAM MARKER <WORDS>  \ Patching WORDS to make it context sensitive :
+
+#require .ID
+{
+\ -- Version 1, MM --
+
+\ Print the name of the word at name address a if it's a member of the wordlist
+\ CONTEXT is ponting to.
+\ ?id ( a -- )
+  :NVM
+    CONTEXT @ OVER ( a wid a ) id? IF SPACE .ID ELSE DROP THEN R> 3 + >R
+  ;RAM ' WORDS $0C + 3 + ULOCKF ! LOCKF   \ patching
+
+  \ ' WORDS $0C + :  dup space .id cell-   \ before patching
+  \                  dup ?id cell-         \ after  patching
+}
+
+\ -- Version 2, TG9541 --
+
+: nops ( a n -- a+n ) 2DUP $9D FILL + ;
+
+\ Print the name of the word at name address a if it's a member of the wordlist
+\ CONTEXT is ponting to.
+\ ?id ( a -- )
+  :NVM
+    CONTEXT @ OVER ( a wid a ) id? IF SPACE .ID ELSE DROP THEN
+  ;RAM ' WORDS $0E + ULOCKF 3 nops 1+ ! LOCKF   \ patching
+
+  \ ' WORDS $0C + :  dup space .id cell-   \ before patching
+  \                  dup NOP   ?id cell-   \ after  patching
+
+<WORDS>
+
+{ \ for debugging only
+
+  RAM MARKER <v>
+
+#require WORD
+
+  : v ( "name" -- ) BL WORD CONTEXT find .S 2DROP ;
+
+}
+
+
+RAM MARKER <TOKSNAME>  \ Patching TOKSNAME to support context tagging :
+
+  \ tg? ( -- f ) \ f <> 0 if CURRENT <> 0
+  :NVM CURRENT @ ;RAM ALIAS tg?
+
+RAM MARKER <tg+>
+
+#require LAST
+
+  \ tg+ ( -- ) \ Set the tg-bit of the last created word.
+  :NVM
+     LAST @ DUP C@ $20 OR SWAP C!
+     \ ."  tagged "  \ debugging only
+  ;RAM <tg+> ALIAS tg+
+
+  \ tg, ( -- ) \ compile CURRENT as context tag
+  :NVM
+    CURRENT @ ,
+    \ ."  tg, "  \ debugging only
+  ;RAM ALIAS tg,
+
+#require PARSE
+#require PACK$
+#require $,n
+
+  \ nTOKSNAME ( "name" -- )
+  :NVM
+      BL PARSE  ( na )
+      DUP C@ IF tg? IF tg, THEN THEN
+      HERE      ( na here )
+      2+ PACK$
+      $,n
+      tg? IF tg+ THEN
+  ;RAM ALIAS nTOKSNAME
+
+
+  :NVM \ patching TOKSNAME
+    nTOKSNAME R> DROP
+  ;RAM ' CREATE 1+ @ 1+ ULOCKF ! LOCKF   \ patching
+
+<TOKSNAME>
+
+NVM
+
+HERE size @ - . .(  NVM bytes used )  
+
+RAM
+
+#require PERSIST
+
+PERSIST  RAM WIPE
+
+\ ------------------------------------------------------------------------------
+\ Last Revision: MM-171220 stm8ef License added, V1.0 released
+\                MM-171204 WORDS patch: Proposal from TG9541 applied
+\                MM-171127 Introduction, Glossary and Implementation Notes
+\                          added.
+\                MM-171126 Comments added, WIPE added.
+\                MM-171124 Code cleaned up.
+
+\\
+
+\ Implementation Notes:
+
+\ Traditionally contexts/wordlists/namespaces are implemented in Forth as linked
+\ lists. This is memory efficient and easy to do for RAM based systems but not
+\ so adaquate for NVM/Flash based ones.
+
+\ Here we use the single stm8ef wordlist for all words in the dictionary. Words
+\ that are not created as a member of the Forth wordlist are then tagged with 
+\ the wordlist identifier (wid) of the wordlist they are assigned to.
+
+\ This is easy to implement in NVM based systems and adding and forgetting words
+\ does not require any extra internal garbadge handling.
+
+\ Tagging a word means to compile the wid in front of the words link-field and 
+\ to set the lexicon tag bit ( TAGGE = 0x20 ) in the (count) byte at the words
+\ name address. This bit is not used by the stm8ef core itself.
+
+\   TAGGE   =     0x20      ; lexicon tag bit
+\   COMPO   =     0x40      ; lexicon compile only bit
+\   IMEDD   =     0x80      ; lexicon immediate bit
+\   MASKK   =     0x1F7F    ; lexicon bit mask
+
+\ Any unique non-zero number can be used as a tag (wid). Zero is reseved for 
+\ the FORTH wordlist. (The words of the FORTH wordlist are not tagged.)
+

--- a/lib/DEFINITIONS
+++ b/lib/DEFINITIONS
@@ -1,0 +1,14 @@
+\ stm8ef: DEFINITIONS                                                  MM-171128
+\ License see github.com/TG9541/stm8ef/blob/master/LICENSE.md
+
+#require CURRENT  \ persistent support for context switching
+
+NVM
+
+\ Set the top wordlist of the search order as compiler context.
+: DEFINITIONS ( -- ) CONTEXT @ CURRENT ! ;
+
+RAM
+
+\ Last Revision: MM-171220 License added
+

--- a/lib/FORTH
+++ b/lib/FORTH
@@ -1,0 +1,14 @@
+\ stm8ef: FORTH                                                        MM-171128
+\ License see github.com/TG9541/stm8ef/blob/master/LICENSE.md
+
+#require CURRENT  \ persistent support for context switching
+
+NVM
+
+\ Set the FORTH wordlist as top of the search order.
+: FORTH ( -- ) 0 CONTEXT ! ;
+
+RAM
+
+\ Last Revision: MM-171220 License added
+

--- a/lib/SEARCH-WORDLIST
+++ b/lib/SEARCH-WORDLIST
@@ -1,0 +1,10 @@
+\ stm8et: SEARCH-WORDLIST                                              MM-171124
+
+#require CURRENT
+
+RAM
+
+#require ALIAS
+
+' nFIND 3 + ALIAS SEARCH-WORDLIST ( a wid -- xt na | a ff )
+

--- a/lib/VOC
+++ b/lib/VOC
@@ -1,0 +1,121 @@
+\ stm8ef: VOC                                                          MM-171116
+\
+\               Copyright (C) 2017 manfred.mahlow@forth-ev.de
+\
+\        License see github.com/TG9541/stm8ef/blob/master/LICENSE.md
+\
+\                A Vocabulary Prefix for the STM8S eForth.
+\
+\ Vocabulary prefixes help to structure the dictionary, make it more readable.
+\
+\ A vocabulary prefix is an immediate word. It reads the next word from the 
+\ input stream, finds it in its private wordlist and then executes or compiles
+\ it. Throws an error if the input stream is empty.
+\
+\ Usage: #require VOC      \ loads this file
+\
+\        VOC name          \ creates a new vocabulary prefix
+\
+\        name DEFINITIONS  \ makes name (names wordlist) the current compilation
+\                          \ context 
+\
+\ Example:  VOC i2c  i2c DEFINITIONS
+\
+\             VARIABLE sid   \ slave id
+\
+\             : start ... ;  \ start an I2C Bus transmission
+\
+\             ...            \ more I2C definitions
+\
+\           FORTH DEFINITIONS
+\
+\           i2c words    \ shows all words of the i2c context
+\           i2c start    \ executes/compiles the word start from context i2c    
+\ ------------------------------------------------------------------------------
+\ requires stm8ef > 2.2.19
+
+#require CURRENT  \ persistent support for context switching
+
+RAM WIPE
+
+RAM  VARIABLE size   NVM  HERE size !   \ for code size monitoring only
+
+#require DEFINITIONS
+#require FORTH
+
+FORTH DEFINITIONS
+
+RAM
+
+\ #require ?RAM     MM-171203
+#require :NVM
+#require ALIAS
+#require 'EVAL
+#require WORD
+#require ABORT"
+#require LAST
+#require COMPILE
+
+NVM
+
+VARIABLE VP  0 VP !   \ VP = wid of voc-root
+                      \ VP @ = wid of the last used VOC
+
+LAST @ CONSTANT VP0   \ wid of voc-root
+
+RAM
+
+' find 3 + ALIAS search-wordlist ( a wid -- xt na | a ff )
+
+\ search-voc ( "name" -- xt na | a ff )
+  :NVM
+    BL WORD VP @ ( a wid )
+    search-wordlist ( a wid -- xt na | a ff ) ?DUP IF EXIT THEN
+    VP0 search-wordlist
+  ;RAM ALIAS search-voc
+
+\ dovpx ( "name" -- )
+  :NVM
+     R> @ VP ! search-voc 'EVAL @ 3 + EXECUTE 
+  ;RAM ALIAS dovpx
+
+NVM
+
+\ Create a vocabulary prefix.
+: VOC ( "name" -- )
+  : COMPILE dovpx LAST @ , [COMPILE] [ OVERT IMMEDIATE
+;
+
+VP0 CURRENT !  \ voc-root definitions
+
+\ Set the wordlist of the active vocabulary prefix as compiler context.
+: DEFINITIONS ( -- ) VP @ CURRENT ! ;
+
+\ Return the execution token of the name on the stack.
+: ' ( "name" -- xt ) search-voc 0= ABORT" " ;
+
+\ Display all words of the wordlist of the active vocabulary prefix.
+: WORDS ( -- )
+  CONTEXT @ VP @ CONTEXT ! WORDS VP0 CONTEXT ! WORDS CONTEXT !
+;
+ 
+FORTH DEFINITIONS
+
+NVM
+
+\ MM-171203
+\ Switch to NVM mode but abort with a message if CURRENT points to a wordlist 
+\ in the RAM. (All words of a VOC defined in RAM should also be defined in RAM.)
+: NVM ( -- ) 0 CURRENT @ < ABORT" RAM only" NVM ;
+
+NVM HERE size @ - . .(  NVM bytes used )  
+
+RAM WIPE
+
+\ ------------------------------------------------------------------------------
+\ Last Revision: MM-171220  License added
+\                MM-171203  A VOC can now also be created in RAM, ?RAM no longer
+\                           required, NVM redefined, VP0 added, returns the wid
+\                           of voc-root (the name address of VP)
+\                MM-171128  ?RAM added, FORTH and DEFINITIONS factored out.
+

--- a/lib/VOCABULARY
+++ b/lib/VOCABULARY
@@ -1,0 +1,51 @@
+\ stm8ef: VOCABULARY                                                   MM-171124
+\ ------------------------------------------------------------------------------
+\ License see github.com/TG9541/stm8ef/blob/master/LICENSE.md
+
+\ requires stm8ef > 2.2.19
+
+#require CURRENT  \ persistent support for context switching
+
+RAM WIPE
+
+#require FORTH
+#require DEFINITIONS
+
+FORTH DEFINITIONS
+
+#require ALIAS
+#require :NVM
+#require LAST
+#require [COMPILE]
+#require ABORT"
+
+:NVM R> @ CONTEXT ! ;RAM ALIAS dovoc ( "name" -- )
+
+NVM
+
+: VOCABULARY ( "name" -- )
+  : COMPILE dovoc LAST @ , [COMPILE] [ OVERT IMMEDIATE
+;
+
+\ MM-171203
+\ Switch to NVM mode but abort with a message if CURRENT points to a wordlist 
+\ in the RAM. (All words of a VOCABULARY defined in RAM should also be defined
+\ in RAM.)
+: NVM ( -- ) 0 CURRENT @ < ABORT" RAM only" NVM ;
+
+RAM WIPE
+
+#require .ID
+
+NVM
+
+: .VOC ( wid -- ) ?DUP IF .ID ELSE ." FORTH" THEN ;
+
+: ORDER ( -- ) CONTEXT DUP @ SPACE .VOC  2+ @ SPACE .VOC ;
+
+RAM WIPE
+
+\ ------------------------------------------------------------------------------
+\ Last Revision: MM-171220 License added
+\                MM-171203 NVM redefined, ?RAM no longer required, VOCABULARY
+\                          is now supported in RAM and NVM mode.

--- a/lib/WIPE
+++ b/lib/WIPE
@@ -1,0 +1,25 @@
+\ stm8ef: WIPE                                                        MM-171125
+\ License see github.com/TG9541/stm8ef/blob/master/LICENSE.md
+
+RAM
+
+#require NVMCONTEXT
+#require LAST
+#require CTOP
+#require CP
+
+#require :NVM
+#require ALIAS
+
+NVM
+
+: WIPE ( -- )
+\ Unlink all words from the dictionary that were compiled in RAM mode and reset
+\ the RAM dictionary pointer.
+  NVMCONTEXT @ CTOP @ DUP RAM CP ! 2+ LAST ! , 0 C, OVERT 
+;
+
+RAM WIPE
+
+\ Last Revision: MM-171220 License added
+

--- a/lib/WORDLIST
+++ b/lib/WORDLIST
@@ -1,0 +1,84 @@
+\ stm8ef: WORDLIST                                                     MM-171123
+\ ------------------------------------------------------------------------------
+\ License see github.com/TG9541/stm8ef/blob/master/LICENSE.md
+
+\ requires stm8ef > 2.2.19
+
+#require CURRENT  \ persistent support for context switching
+#require ?RAM
+
+NVM
+
+: WORDLIST ( -- wid )
+\ Return the next free NVM address to be used as a wid and increment the NVM
+\ address pointer by one.
+  HERE NVM HERE SWAP 0 C, ?RAM ;
+
+RAM
+
+\\ MM-171220: License added
+\  MM-171128: ?RAM added
+
+\ ------------------------------------------------------------------------------
+\ Executable WORDLIST Mini Howto:
+\ ------------------------------------------------------------------------------
+  RAM
+
+#require CONSTANT
+
+\ Create a unique wordlist identfier and assign it to a constant.
+  WORDLIST CONSTANT wid0
+
+KEY DROP
+
+\ Make the new wordlist the current compiler context to add words to it.
+  wid0 CURRENT !
+
+KEY DROP
+
+\ Create an alias of .S in the new wordlist.
+  : .S ( -- ) ."  This is .S in the wordlist wid0 " .S ;
+
+KEY DROP
+
+\ Set the new wordlist on top of the search order to make it visible.
+  wid0 CONTEXT !
+
+\ The search order is now  wid0 FORTH.
+
+KEY DROP
+
+\ Display the new wordlist.
+  WORDS
+
+KEY DROP
+
+\ Now entering .S will execute the alias defined in the new wordlist.
+  .S
+
+KEY DROP
+
+\ We create another word in the new wordlist and enter its name to execute it.
+  : hello ."  Hello from wordlist wid0 " ;
+
+  hello
+
+KEY DROP
+
+\ Now we reset the top of the search order to its default (FORTH).
+
+0 CONTEXT !
+
+\ The search order is now FORTH FORTH again.
+
+KEY DROP
+
+\ The words of the wordlist wid0 are no longer visible and give an error, but
+\ they still exist in the dictionary to be used again.
+  hello
+
+KEY DROP
+
+\ But the wordlist and the words are still in the dictionary to be used again.
+
+


### PR DESCRIPTION
Manfred Mahlow contributed an innovative "name space" solution that extends the STM8 eForth dictionary. After some time of testing it has now been added to the library. Although the code contains examples, some work has to go into docs, and test automation. Refer to #130.