### PR TITLE
Test current

### DIFF
--- a/forth.asm
+++ b/forth.asm
@@ -1199,17 +1199,19 @@ SUBB:
 ;       Start vocabulary search.
 
         HEADER  CNTXT "CONTEXT"
+        .ifeq  HAS_CPNVM
 CNTXT:
-        .ifne  HAS_CPNVM
-        CALL    NVMQ
-        JREQ    1$              ; link NVM to NVM
-        LD      A,#(NVMCONTEXT)
-        JRA     ASTOR
-1$:
         .endif
 CNTXT_ALIAS:
         LD      A,#(USRCONTEXT)
         JRA     ASTOR
+        .ifne  HAS_CPNVM
+CNTXT:
+        CALL    NVMQ
+        JREQ    CNTXT_ALIAS           ; link NVM to NVM
+        LD      A,#(NVMCONTEXT)
+        JRA     ASTOR
+        .endif
 
 
 ;       CP      ( -- a )     ( TOS STM8: -- Y,Z,N )

--- a/test/board.fs
+++ b/test/board.fs
@@ -58,7 +58,6 @@ T{ $55AA $0A05 OR -> $5FAF }T
 
 \ core: double arithmetics
 T{ 1 -1 UM+ -> 0 1 }T
-\ uCsim seems to flip BASE to HEX in UM+ or M/MOD opertion!
 T{ 1 -1 -2 M/MOD -> -1 32767 }T
 T{ 1 -1 -2 UM/MOD -> 0 -1 }T
 T{ 1000 -100 500 */ -> -200 }T

--- a/test/board.fs
+++ b/test/board.fs
@@ -133,3 +133,10 @@ T{ 400 CD>TEST cdram -> }T
 T{ cdram -> 800 }T
 
 T{e WORDS e-> 1004 1711 }T
+
+
+\ compile CURRENT and VOC as a test
+COLD
+
+#require CURRENT
+#require VOC

--- a/tools/codeload.py
+++ b/tools/codeload.py
@@ -8,7 +8,7 @@
 #   2. path of the includedfile
 #   3. ./lib
 #   4. ./mcu
-#   5. ./target
+#   5. <base>/target
 
 import sys
 import os
@@ -146,7 +146,8 @@ def searchItem(item, CPATH):
     if not os.path.isfile(searchRes):
         searchRes = os.path.join(CWDPATH, 'mcu', item)
     if not os.path.isfile(searchRes):
-        searchRes = os.path.join(CWDPATH, 'target', item)
+        searchRes = os.path.join(CWDPATH, args.base,'target', item)
+        print(searchRes)
     if not os.path.isfile(searchRes):
         searchRes = os.path.join(CWDPATH, 'lib', item)
     if not os.path.isfile(searchRes):
@@ -269,12 +270,14 @@ parser.add_argument("method", choices=['serial','telnet','dryrun'],
         help="transfer method")
 parser.add_argument("files", nargs='*',
         help="name of one or more files to transfer")
+parser.add_argument("-b", "--target-base", dest="base", default="",
+        help="target base folder, default: ./", metavar="base")
 parser.add_argument("-p", "--port", dest="port",
         help="PORT for transfer, default: /dev/ttyUSB0, localhost:10000", metavar="port")
-parser.add_argument("-t", "--trace", dest="tracefile",
-        help="write source code (with includes) to tracefile", metavar="tracefile")
 parser.add_argument("-q", "--quiet", action="store_false", dest="verbose", default=True,
         help="don't print status messages to stdout")
+parser.add_argument("-t", "--trace", dest="tracefile",
+        help="write source code (with includes) to tracefile", metavar="tracefile")
 args = parser.parse_args()
 
 # create tracefile if needed

--- a/tools/codeload.py
+++ b/tools/codeload.py
@@ -187,12 +187,12 @@ def readEfr(path):
 
 # uploader with resolution of #include, #require, and \res
 def upload(path):
-    reExampleStart = re.compile("^\\\\\\\\")
+    reSkipToEOF = re.compile("^\\\\\\\\")
 
     with open(path) as source:
         vprint('Uploading %s' % path)
         lineNr = 0
-        isExample = False
+        skipLine = False
 
         try:
             CPATH = os.path.dirname(path)
@@ -201,10 +201,17 @@ def upload(path):
                 line = line.replace('\n', ' ').replace('\r', '').strip()
 
                 # all lines from "\\ Example:" on are comments
-                if reExampleStart.match(line):
-                    isExample = True
+                if reSkipToEOF.match(line):
+                    skipLine = True
 
-                if isExample:
+                # e4thcom style block comments (may not end in SkipToEOF section)
+                if re.search('^{', line):
+                    skipLine = True
+
+                if re.search('^} ', line):
+                    skipLine = False
+
+                if skipLine:
                     vprint('\\ ' + line)
                     continue
 

--- a/tools/simload.sh
+++ b/tools/simload.sh
@@ -50,7 +50,7 @@ sleep 0.5
 
 echo "simload.sh: transfer $boardcode"
 
-tools/codeload.py telnet "$boardcode" || exit
+tools/codeload.py -b "out/$object" telnet "$boardcode" || exit
 
 echo "simload.sh: prepare uCsim memory dump to .ihx script"
 


### PR DESCRIPTION
Changes for  #130 
* forth.asm: CURRENT always returns USRCURRENT independent of mode
* automated test for CURRENT and VOC
* simload.sh: use target path (codeload.py -b option)
* codeload extended with e4thcom style source level block comment
