### PR TITLE
Prepare first pre-release for 2.2.21, add initial support for STM8L051F3

### DIFF
--- a/STM8L051F3/boardcore.inc
+++ b/STM8L051F3/boardcore.inc
@@ -1,0 +1,89 @@
+; STM8L051F3P6 "Core" STM8L device dependent routine default code
+
+; Note: for supporting a new board create a new board configuration
+;       folder with a "globconfig.inc" and a copy of this file.
+
+;===============================================================
+
+;      Dummy labels for PSIM interrupts declared in main.c
+
+        .ifne   PSIM-PORTA
+;       Dummy label for _EXTIA_IRQHandler
+_EXTI0_IRQHandler:
+        .endif
+
+        .ifne   PSIM-PORTB
+;       Dummy label for _EXTIB_IRQHandler
+_EXTI1_IRQHandler:
+        .endif
+
+        .ifne   PSIM-PORTC
+;       Dummy label for _EXTIC_IRQHandler
+_EXTI2_IRQHandler:
+        .endif
+
+        .ifne   PSIM-PORTD
+;       Dummy label for _EXTID_IRQHandler
+_EXTI3_IRQHandler:
+        .endif
+
+
+; ==============================================
+
+        .ifne   HAS_LED7SEG
+;       LED_MPX driver ( -- )
+;       Code called from ISR for LED MPX
+
+LED_MPX:
+        RET
+        .endif
+
+; ==============================================
+
+        .ifne   HAS_OUTPUTS
+;       OUT!  ( c -- )
+;       Put c to board outputs, storing a copy in OUTPUTS
+        .dw     LINK
+
+        LINK =  .
+        .db     (4)
+        .ascii  "OUT!"
+OUTSTOR:
+        RET
+        .endif
+
+;===============================================================
+
+        .ifne   HAS_KEYS
+;       BKEY  ( -- f )     ( TOS STM8: -- A,Z,N )
+;       Read board key state as a bitfield
+        .dw     LINK
+
+        LINK =  .
+        .db     (4)
+        .ascii  "BKEY"
+BKEY:
+        CLR     A
+        JP      ASTOR
+
+
+;       BKEYC  (  -- c )   ( TOS STM8: -- A,Z,N )
+;       Read and translate board dependent key bitmap into char
+
+BKEYCHAR:
+        JRA     BKEY            ; Dummy: get "no key" and leave it as it is
+       .endif
+
+;===============================================================
+
+;       BOARDINIT  ( -- )
+;       Init board GPIO (except COM ports)
+
+BOARDINIT:
+        ; Board I/O initialization
+        MOV     CLK_PCKENR1,#0x20
+        BSET    PC_DDR,#5
+        BSET    PC_CR1,#5
+        RET
+
+

--- a/STM8L051F3/globconf.inc
+++ b/STM8L051F3/globconf.inc
@@ -1,0 +1,41 @@
+; STM8EF Global Configuration File
+; Config for STM8L051F3P6
+; Clock: HSI (no crystal)
+
+        HALF_DUPLEX      = 0    ; Use EMIT/?KEY in half duplex mode
+        HAS_TXUART       = 1    ; No UART TXD, word TX!
+        HAS_RXUART       = 1    ; No UART RXD, word ?RX
+        HAS_TXSIM        = 0    ; Enable TxD via GPIO/TIM4, word TXGP!
+        PNTX             = 0    ; Port GPIO# for HAS_TXDSIM
+        HAS_RXSIM        = 0    ; Enable RxD via GPIO/TIM4, word ?RXGP
+        PNRX             = 0    ; Port GPIO# for HAS_RXDSIM
+
+        EMIT_BG  = DROP         ; 7S-LED background EMIT vector
+        QKEY_BG  = ZERO         ; Board keys background QKEY vector
+
+        HAS_LED7SEG      = 0    ; no 7S-Display
+        HAS_KEYS         = 0    ; no keys on module
+        HAS_OUTPUTS      = 0    ; yes, one LED
+        HAS_ADC          = 0    ; Analog input words
+
+        HAS_BACKGROUND   = 0    ; Background Forth task (TIM2 ticker)
+        HAS_CPNVM        = 1    ; Can compile to Flash, always interpret to RAM
+        HAS_DOES         = 1    ; CREATE-DOES> extension
+        HAS_DOLOOP       = 1    ; DO .. LOOP extension: DO LEAVE LOOP +LOOP
+
+
+        CASEINSENSITIVE  = 1    ; Case insensitive dictionary search
+        SPEEDOVERSIZE    = 0    ; Speed-over-size in core words: ROT - = <
+        BAREBONES        = 0    ; Remove or unlink some more: hi HERE .R U.R SPACES @EXECUTE AHEAD CALL, EXIT COMPILE [COMPILE]
+
+        WORDS_LINKINTER  = 0    ; Link interpreter words: ACCEPT QUERY TAP kTAP hi 'BOOT tmp >IN 'TIB #TIB eval CONTEXT pars PARSE NUMBER? DIGIT? WORD TOKEN NAME> SAME? find ABORT aborq $INTERPRET INTER? .OK ?STACK EVAL PRESET QUIT $COMPILE
+        WORDS_LINKCOMP   = 0    ; Link compiler words: cp last OVERT $"| ."| $,n
+        WORDS_LINKRUNTI  = 0    ; Link runtime words: doLit do$ doVAR donxt dodoes ?branch branch
+        WORDS_LINKCHAR   = 1    ; Link char out words: DIGIT <# # #S SIGN #> str hld HOLD
+        WORDS_LINKMISC   = 0    ; Link composing words of SEE DUMP WORDS: >CHAR _TYPE dm+ .ID >NAME
+
+        WORDS_EXTRASTACK = 0    ; Link/include stack core words: rp@ rp! sp! sp@ DEPTH
+        WORDS_EXTRADEBUG = 0    ; Extra debug words: SEE
+        WORDS_EXTRACORE  = 1    ; Extra core words: =0 I
+        WORDS_EXTRAMEM   = 1    ; Extra memory words: B! 2C@ 2C!
+        WORDS_EXTRAEEPR  = 1    ; Extra EEPROM lock/unlock words: LOCK ULOCK ULOCKF LOCKF

--- a/STM8L051F3/target.inc
+++ b/STM8L051F3/target.inc
@@ -1,0 +1,13 @@
+;       STM8L051F3 device and memory layout configuration
+
+        TARGET = STM8L051F3
+
+        RAMEND =        0x03FF  ; system (return) stack, growing down
+        EEPROMEND =     0x41FF  ; STM8L051F3: 256 bytes EEPROM
+        FLASHEND =      0x9FFF  ; 8K devices
+
+        FORTHRAM =      0x0040  ; Start of RAM controlled by Forth
+        UPPLOC  =       0x0060  ; UPP (user/system area) location for 1K RAM
+        CTOPLOC =       0x0080  ; CTOP (user dictionary) location for 1K RAM
+        SPPLOC  =       0x0350  ; SPP (data stack top), TIB start
+        RPPLOC  =       RAMEND  ; RPP (return stack top)

--- a/forth.asm
+++ b/forth.asm
@@ -106,6 +106,7 @@
         BRAN_OPC =    0xCC      ; JP opcode
         CALL_OPC =    0xCD      ; CALL opcode
 
+        STM8L051F3       = 051  ; L core, 8K flash, 1K RAM, 256 EEPROM, UART1
         STM8S003F3       = 103  ; 8K flash, 1K RAM, 128 EEPROM, UART1
         STM8S103F3       = 103  ; like STM8S003F3, 640 EEPROM
         STM8S105K4       = 105  ; 16K flash, 2K RAM, 1K EEPROM, UART2
@@ -125,7 +126,11 @@
         .include        "target.inc"
 
         ; STM8 unified register addresses (depends on "TARGET")
+        .ifeq   (TARGET - STM8L051F3)
+        .include        "stm8ldevice.inc"
+        .else
         .include        "stm8device.inc"
+        .endif
 
         ;**********************************
         ;******  3) Global defaults  ******

--- a/inc/defconf.inc
+++ b/inc/defconf.inc
@@ -3,7 +3,7 @@
 ;       Default settings for all kinds of options
 ;--------------------------------------------------------
         RELVER1          = 2    ; Revision digit 1
-        RELVER0          = 0    ; Revision digit 0
+        RELVER0          = 1    ; Revision digit 0
 
         TERM_LINUX       = 1    ; LF terminates line
         HALF_DUPLEX      = 0    ; Use EMIT/?KEY in half duplex mode

--- a/inc/linkopts.inc
+++ b/inc/linkopts.inc
@@ -23,7 +23,7 @@
         UNLINK_FIND      = 0    ; "find"    ; parser
         UNLINK_BKSP      = 0    ; "^h"     ; charInput
         UNLINK_TAP       = 0    ; "TAP"    ; charInput
-        UNLINK_KTAP      = 0    ; "kTAP"   ; charInput 
+        UNLINK_KTAP      = 0    ; "kTAP"   ; charInput
         UNLINK_ACCEP     = 0    ; "ACCEPT" ; charInput
         UNLINK_QUERY     = 0    ; "QUERY"  ; charInput
         UNLINK_ABORT     = 0    ; "ABORT"  ; REPL
@@ -32,9 +32,7 @@
         UNLINK_INTER     = 0    ; "$INTERPRET" ; REPL -
         UNLINK_SCOMP     = 0    ; "$COMPILE" ; REPL -
         UNLINK_DOTOK     = 0    ; ".OK" ; REPL
-        UNLINK_QSTAC     = 0    ; "?STACK" ; REPL  
-        UNLINK_EVAL      = 0    ; "EVAL"  ; REPL 
+        UNLINK_QSTAC     = 0    ; "?STACK" ; REPL
+        UNLINK_EVAL      = 0    ; "EVAL"  ; REPL
         UNLINK_QUIT      = 0    ; "QUIT"  ; REPL
         .endif
-
-


### PR DESCRIPTION
Adds initial support for STM8L051F3.
Tested so far:
* serial console through PC5 (pin1) TXD, PC6 (pin2) RXD
* RAM and NVM modes

Known problems:
The Background Task doesn't work yet (it's switched off)