### PR TITLE
Refactor test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,8 @@ main.ihx: main.c $(MDEPS)
 	sdcc -mstm8 -I./$(BOARD) -I./inc -oout/$(BOARD)/$(BOARD).ihx main.c out/$(BOARD)/forth.rel
 	mkdir -p out/$(BOARD)/target
 	rm -f out/$(BOARD)/target/*
+	rm -f target
+	ln -s out/$(BOARD)/target/ target
 	tools/genalias.awk -v target="out/$(BOARD)/target/" out/$(BOARD)/forth.rst
 	tools/genconst.awk -v target="out/$(BOARD)/target/" out/$(BOARD)/forth.rst
 

--- a/inc/board_io.inc
+++ b/inc/board_io.inc
@@ -1,0 +1,183 @@
+;--------------------------------------------------------
+;       STM8 eForth Board I/O
+;       key input, and LED 7-segment LED display output
+;--------------------------------------------------------
+
+        .ifne   HAS_KEYS
+
+;       ?KEYB   ( -- c T | F )  ( TOS STM8: -- Y,Z,N )
+;       Return keyboard char and true, or false if no key pressed.
+
+        HEADER  QKEYB "?KEYB"
+QKEYB:
+        CALL    BKEYCHAR        ; Read char from keyboard (option: vectored code)
+        CALL    AFLAGS
+
+        JRNE    KEYBPRESS
+        ; Bit7: flag press + 100*5ms hold before repetition
+        MOV     KEYREPET,#(0x80 + 100)
+        JRA     NOKEYB
+KEYBPRESS:
+        BTJF    KEYREPET,#7,KEYBHOLD
+        BRES    KEYREPET,#7
+        JRA     ATOKEYB
+KEYBHOLD:
+        DEC     KEYREPET
+        JRNE    NOKEYB
+        MOV     KEYREPET,#30    ; repetition time: n*5ms
+ATOKEYB:
+        JP      ATOKEY          ; push char and flag true
+NOKEYB:
+        JP      ZERO            ; push flag false
+
+        .endif
+
+        .ifne   HAS_LED7SEG
+
+;       7-seg LED patterns, "70s chique"
+PAT7SM9:
+        .db     0x00, 0x40, 0x80, 0x52 ; , - . / (',' as blank)
+        .db     0x3F, 0x06, 0x5B, 0x4F ; 0,1,2,3
+        .db     0x66, 0x6D, 0x7D, 0x07 ; 4,5,6,7
+        .db     0x7F, 0x6F             ; 8,9
+PAT7SAZ:
+        .db           0x77, 0x7C, 0x39 ;   A,B,C
+        .db     0x5E, 0x79, 0x71, 0x3D ; D,E,F,G
+        .db     0x74, 0x30, 0x1E, 0x7A ; H,I,J,K
+        .db     0x38, 0x55, 0x54, 0x5C ; L,M,N,O
+        .db     0x73, 0x67, 0x50, 0x6D ; P,Q,R,S
+        .db     0x78, 0x3E, 0x1C, 0x1D ; T,U,V,W
+        .db     0x76, 0x6E, 0x5B       ; X,Y,Z
+
+;       E7S  ( c -- )
+;       Convert char to 7-seg LED pattern, and insert it in display buffer
+
+        HEADER  EMIT7S "E7S"
+EMIT7S:
+        LD      A,(1,X)         ; c to A
+
+        CP      A,#' '
+        JRNE    E7SNOBLK
+
+        .if     gt,(HAS_LED7SEG-1)
+        LD      A,LED7GROUP
+        JRMI    2$              ; test LED7GROUP.7 "no-tab flag"
+        INC     A
+        CP      A,#HAS_LED7SEG
+        JRULT   1$
+        CLR     A
+1$:     OR      A,#0x80         ; only one tab action, set "no-tab flag"
+        LD      LED7GROUP,A
+
+2$:     CALLR   XLEDGROUP
+        EXGW    X,Y             ; restore X/Y after XLEDGROUP
+        .else
+        LDW     Y,#LED7FIRST    ; DROP DOLIT LED7FIRST
+        .endif
+        LDW     (X),Y
+        DoLitC  LEN_7SGROUP
+        JP      ERASE
+
+E7SNOBLK:
+
+        .if     gt,(HAS_LED7SEG-1)
+        CP      A,#LF           ; test for c ~ /[<CR><LF>]/
+        JRNE    E7SNOLF
+        MOV     LED7GROUP,#0x80 ; go to first LED group, set "no-tab flag"
+        JRA     E7END
+        .endif
+
+E7SNOLF:
+        .if     gt,(HAS_LED7SEG-1)
+        BRES    LED7GROUP,#7    ; on char output: clear "no-tab flag"
+        .endif
+
+        CP      A,#'.'
+        JREQ    E7DOT
+        CP      A,#','
+        JRMI    E7END
+        CP      A,#'z'
+        JRPL    E7END
+        CP      A,#'A'
+        JRUGE   E7ALPH
+
+        ; '-'--'9' (and '@')
+        SUB     A,#','
+        LD      (1,X),A
+        DoLitW  PAT7SM9
+        JRA     E7LOOKA
+E7ALPH:
+        ; 'A'--'z'
+        AND     A,#0x5F         ; convert to uppercase
+        SUB     A,#'A'
+        LD      (1,X),A
+        DoLitW  PAT7SAZ
+E7LOOKA:
+        CALL    PLUS
+        CALL    CAT
+        JP      PUT7S
+
+E7DOT:
+        .if     gt,(HAS_LED7SEG-1)
+        CALL    XLEDGROUP
+        LD      A,((LEN_7SGROUP-1),X)
+        OR      A,#0x80
+        LD      ((LEN_7SGROUP-1),X),A
+        EXGW    X,Y             ; restore X/Y after XLEDGROUP
+        ; fall trough
+
+        .else
+        LD      A,#0x80         ; 7-seg P (dot)
+        OR      A,LED7LAST
+        LD      LED7LAST,A
+        .endif
+        ; fall trough
+
+E7END:
+        JP      DROP
+
+        .if     gt,(HAS_LED7SEG-1)
+;       Helper routine for calculating LED group start adress
+;       return: X: LED group addr, Y: DSP, A: LEN_7SGROUP
+;       caution: caller must restore X/Y!
+XLEDGROUP:
+        EXGW    X,Y             ; use X to save memory
+        LD      A,LED7GROUP
+        AND     A,#0x7F         ; ignore "no-tab flag"
+        LD      XL,A
+        LD      A,#LEN_7SGROUP
+        MUL     X,A
+        ADDW    X,#LED7FIRST
+        RET
+        .endif
+
+;       P7S  ( c -- )
+;       Right aligned 7S-LED pattern output, rotates LED group buffer
+
+        HEADER  PUT7S "P7S"
+PUT7S:
+        .if     gt,(HAS_LED7SEG-1)
+        CALLR   XLEDGROUP
+        DEC     A
+        PUSH    A
+1$:     LD      A,(1,X)
+        LD      (X),A
+        INCW    X
+        DEC     (1,SP)
+        JRNE    1$
+        POP     A
+
+        EXGW    X,Y             ; restore X/Y after XLEDGROUP
+        CALL    AFLAGS
+        LD      (Y),A
+        .else
+        DoLitC  LED7FIRST+1
+        DoLitC  LED7FIRST
+        DoLitC  (LEN_7SGROUP-1)
+        CALL    CMOVE
+        CALL    AFLAGS
+        LD      LED7LAST,A
+        .endif
+
+        RET
+        .endif

--- a/inc/defconf.inc
+++ b/inc/defconf.inc
@@ -300,3 +300,4 @@
         UNLINK_RESETT    = 0    ; "RESET"
         UNLINK_SAVEC     = 0    ; "SAVEC"
         UNLINK_RESTC     = 0    ; "IRET"
+        UNLINK_WIPE      = 1    ; "WIPE"

--- a/inc/defconf.inc
+++ b/inc/defconf.inc
@@ -140,7 +140,7 @@
         UNLINK_QDUP      = 0    ; "?DUP"
         UNLINK_ROT       = 0    ; "ROT"
         UNLINK_DDUP      = 0    ; "2DUP"
-        UNLINK_DNEGA     = 0    ; "DNEGATE"
+        UNLINK_DNEGA     = 1    ; "DNEGATE"
         UNLINK_EQUAL     = 0    ; "="
         UNLINK_ULESS     = 0    ; "U<"
         UNLINK_LESS      = 0    ; "<"
@@ -197,7 +197,7 @@
         UNLINK_NUFQ      = 0    ; "NUF?"
         REMOVE_NUFQ      = 1    ; remove "NUF?"
         UNLINK_SPACE     = 0    ; "SPACE"
-        UNLINK_SPACS     = 0    ; "SPACES"
+        UNLINK_SPACS     = 1    ; "SPACES"
         UNLINK_CR        = 0    ; "CR"
         UNLINK_DOSTR     = 1    ; "do$"
         UNLINK_STRQP     = 1    ; '$"|'

--- a/inc/stm8_adc.inc
+++ b/inc/stm8_adc.inc
@@ -1,0 +1,30 @@
+;--------------------------------------------------------
+;       STM8 eForth           STM8S Family ADC code 
+;--------------------------------------------------------
+        
+        .ifne   HAS_ADC
+;       ADC!  ( c -- )
+;       Init ADC, select channel for conversion
+
+        HEADER  ADCSTOR "ADC!"
+ADCSTOR:
+        INCW    X
+        LD      A,(X)
+        INCW    X
+        AND     A,#0x0F
+        LD      ADC_CSR,A       ; select channel
+        BSET    ADC_CR2,#3      ; align ADC to LSB
+        BSET    ADC_CR1,#0      ; enable ADC
+        RET
+
+;       ADC@  ( -- w )
+;       start ADC conversion, read result
+
+        HEADER  ADCAT "ADC@"
+ADCAT:
+        BRES    ADC_CSR,#7      ; reset EOC
+        BSET    ADC_CR1,#0      ; start ADC
+1$:     BTJF    ADC_CSR,#7,1$   ; wait until EOC
+        LDW     Y,ADC_DRH       ; read ADC
+        JP      YSTOR
+        .endif

--- a/lib/D-
+++ b/lib/D-
@@ -1,6 +1,7 @@
 \ D-            double maths utility word (C) RigTig 2017
 \ refer to github.com/TG9541/stm8ef/blob/master/LICENSE.md
 
+#require DNEGATE
 #require D+
 
 : D- ( d d -- d )

--- a/lib/DABS
+++ b/lib/DABS
@@ -1,4 +1,6 @@
 \ STM8 eForth DABS   double math utility word       TG9541
 \ refer to github.com/TG9541/stm8ef/blob/master/LICENSE.md
 
+#require DNEGATE
+
 : DABS  ( d -- d ) DUP 0< IF DNEGATE THEN ;

--- a/test/board.fs
+++ b/test/board.fs
@@ -1,7 +1,7 @@
 #include utils/tester.fs
 
 \ expected vocabulary (including tester.fs)
-T{e WORDS e-> 969 -1358 }T
+T{e WORDS e-> 954 -2373 }T
 
 \ core: string with capured EMIT
 : test-."" ." abc123" ;
@@ -74,7 +74,6 @@ T{ 1000 -100 500 */ -> -200 }T
 T{ -1000 55 101 */MOD -> 45 -545 }T
 T{ -1 -1 UM* -> 1 -2 }T
 T{ 31 -3010 M* -> -27774 -2 }T
-T{ -27774 -2 DNEGATE -> 27774 1 }T
 
 \ NVM features, 'BOOT vector, and COLD
 NVM
@@ -124,10 +123,46 @@ T{  -20 30 -10 gd7 -> 30 20 10  0 -10 -20 6  }T
 T{  -20 31 -10 gd7 -> 31 21 11  1  -9 -19 6  }T
 T{  -20 29 -10 gd7 -> 29 19  9 -1 -11     5  }T
 
+\ start over - we'll need some RAM
 COLD
+#include utils/tester.fs
+
+#require 2ROT
+T{ 11 1 22 2 33 3 2ROT -> 22 2 33 3 11 1 }T
+#require 2OVER
+T{ 11 1 22 2 2OVER -> 11 1 22 2 11 1 }T
+#require 2SWAP
+T{ 11 1 22 2 2SWAP -> 22 2 11 1 }T
+
+#require DNEGATE
+#require DABS
+#require D+
+#require D-
+#require D<
+#require D=
+T{ 27774 1 DNEGATE -> -27774 -2 }T
+T{ -27774 -2 DABS -> 27774 1 }T
+T{ -27774 1 DABS -> -27774 1 }T
+T{ 1 -1 1 2 D+ -> 2 1 }T
+T{ 2 1 1 2 D- -> 1 -1 }T
+T{ 1 -1 2 -1 D< -> -1 }T
+T{ 2 -1 1 -1 D< -> 0 }T
+T{ 1 1 1 1 D< -> 0 }T
+T{ 2 1 1 1 D< -> 0 }T
+T{ 1 1 2 1 D< -> -1 }T
+T{ 1 1 1 1 D= -> -1 }T
+
+\ start over - we'll need some RAM
+COLD
+#include utils/tester.fs
+
+#require DSQRT
+T{ 16960 15 DSQRT -> 1000 }T
 
 \ start over and check if words were persisted
+COLD
 #include utils/tester.fs
+
 T{e startNVM e-> 4 260 }T
 T{ varNVM -> 128 }T
 
@@ -142,7 +177,7 @@ RAM
 T{ 400 CD>TEST cdram -> }T
 T{ cdram -> 800 }T
 
-T{e WORDS e-> 1005 1743 }T
+T{e WORDS e-> 990 728 }T
 
 
 \ compile CURRENT and VOC as a test


### PR DESCRIPTION
* board-io code moved to board_io.inc
* ADC code moved to stm8_adc.inc
* SPACES unlinked from dictionary
* DNEGATE unlinked from dictionary
* automated tests for double words added
* make BOARD=<board> now creates a symlink "/out/<board>/target" to "./target"