### PR TITLE
fix gawk and() for negative argument

### DIFF
--- a/tools/simload.sh
+++ b/tools/simload.sh
@@ -60,7 +60,7 @@ read -d '' makeHex << 'EOF'
   cs=0; a=":"; g=$0; n=gsub(/ 0x/,"",g)
   App(Xpr(n),1); App($1,4); App($1,6); App("00",1)
   for (i=2; i<=(n+1); i++) { App($i,3) }
-  print a Xpr(and(-cs,0xFF))
+  print a Xpr(and(256*int(cs/256+1)-cs,0xFF))
 }
 END { print ":00000001FF" }
 function Xpr(x) { return sprintf("%02x",x) }


### PR DESCRIPTION
When using `gawk` (GNU Awk 4.2.1) `simload.sh` fails with this message

```
simload.sh: extract W1209-CA-forth.ihx binary and exit uCsim
gawk: cmd. line:5: (FILENAME=- FNR=7) fatal: and: argument 2 negative value -128 is not allowed
```


According to the docs https://www.gnu.org/software/gawk/manual/html_node/Bitwise-Functions.html#Bitwise-Functions

> CAUTION: Beginning with gawk version 4.2, negative operands are not allowed for any of these functions. A negative operand produces a fatal error. See the sidebar “Beware The Smoke and Mirrors!” for more information as to why. 

An easy check
```
$ gawk 'BEGIN{print and(6,3)}'
2
$ gawk 'BEGIN{print and(-6,3)}'
gawk: cmd. line:1: fatal: and: argument 2 negative value -6 is not allowed
```
BTW some awk's (mawk, nawk) do not even have bitwise operations, so this could lead to further problems.
