### PR TITLE
typo MODD/MMOD

### DIFF
--- a/forth.asm
+++ b/forth.asm
@@ -1764,7 +1764,7 @@ SLMOD:
 ;       Signed divide. Return mod only.
 
         HEADER  MMOD "MOD"
-MODD:
+MMOD:
         CALLR   SLMOD
         JP      DROP
 


### PR DESCRIPTION
Label for "MOD" should be MMOD