### PR TITLE
STM8L-DISCOVERY: enable UART output

### DIFF
--- a/STM8L-DISCOVERY/boardcore.inc
+++ b/STM8L-DISCOVERY/boardcore.inc
@@ -15,6 +15,8 @@ BOARDINIT:
         ; Board I/O initialization
         MOV     CLK_PCKENR1,#0x21   ; Enable USART1[5] and TIM2[0]
         MOV     SYSCFG_RMPCR1,#0x10 ; Map USART1 to PA2[TX] and PA3[RX]
+        BSET    PA_DDR,#2 ; Setup PA2[USART1_TX] as output
+        BSET    PA_CR1,#2 ; Setup PA2[USART1_TX] as push-pull output
 
         ; Leds init
         BSET    PE_DDR,#7 ; PE7 LED green


### PR DESCRIPTION
The BOARDINIT routine from STM8L-DISCOVERY/boardcore.inc
remaps UART interface to PA2/PA3 pins but the PA2 output
mode set code is missed. As a result UART produces
no output.

The commit fixes the problem by setting up PA2 as
push-pull output.

Signed-off-by: Antony Pavlov <antonynpavlov@gmail.com>