### PR TITLE
Init macros

### DIFF
--- a/STM8S001J3/boardcore.inc
+++ b/STM8S001J3/boardcore.inc
@@ -83,9 +83,6 @@ BKEYCHAR:
 
 BOARDINIT:
         ; Board I/O initialization
-        ; pull-up for PD5 single-wire UART
-        BRES    PD_DDR,#5       ; PD5 GPIO input high
-        BRES    PD_CR1,#5       ; PD5 GPIO pull-up
 
         RET
 

--- a/STM8S001J3/globconf.inc
+++ b/STM8S001J3/globconf.inc
@@ -3,7 +3,7 @@
 ; Clock: HSI (no crystal)
 
 
-        HALF_DUPLEX      = 1    ; Use UART in half duplex mode
+        HALF_DUPLEX      = 2    ; Use UART in half duplex mode
         HAS_TXUART       = 1    ; UART TXD, word TX!
         HAS_RXUART       = 1    ; UART RXD, word ?RX
         HAS_TXSIM        = 0    ; Enable TxD via GPIO/TIM4, word TXGP!

--- a/forth.asm
+++ b/forth.asm
@@ -540,6 +540,27 @@ COLD:
         .ifne   HAS_RXUART*HAS_TXUART
         MOV     UART_CR2,#0x0C  ; Use UART1 full duplex
         .ifne   HALF_DUPLEX
+        .ifeq   (HALF_DUPLEX - 1)
+        ; pull-up for PD5 single-wire UART
+        BRES    PD_DDR,#5       ; PD5 GPIO input high
+        BSET    PD_CR1,#5       ; PD5 GPIO pull-up
+        .endif
+        .ifeq   (HALF_DUPLEX - 2)
+        ; STM8S903 type Low Density devices can re-map UART-TX to PA3
+        LD      A,OPT2
+        AND     A,#0x03
+        CP      A,#0x03
+        JREQ    $1
+        ; pull-up for PD5 single-wire UART
+        BRES    PD_DDR,#5       ; PD5 GPIO input high
+        BSET    PD_CR1,#5       ; PD5 GPIO pull-up
+        JRA     $2
+$1:
+        ; pull-up for PA3 single-wire UART
+        BRES    PA_DDR,#3       ; PA3 GPIO input high
+        BSET    PA_CR1,#3       ; PA3 GPIO pull-up
+$2:
+        .endif
         MOV     UART1_CR5,#0x08 ; UART1 Half-Duplex
         .endif
         .else

--- a/inc/board_io.inc
+++ b/inc/board_io.inc
@@ -5,6 +5,8 @@
 
         .ifne   HAS_KEYS
 
+        RamByte KEYREPET        ; board key repetition control (8 bit)
+
 ;       ?KEYB   ( -- c T | F )  ( TOS STM8: -- Y,Z,N )
 ;       Return keyboard char and true, or false if no key pressed.
 
@@ -33,6 +35,15 @@ NOKEYB:
         .endif
 
         .ifne   HAS_LED7SEG
+
+        .if     gt,(HAS_LED7SEG-1)
+        RamByte LED7GROUP       ; byte index of 7-SEG digit group
+        .endif
+
+        DIGITS = HAS_LED7SEG*LEN_7SGROUP
+        RamBlck LED7FIRST,DIGITS ; leftmost 7S-LED digit
+        LED7LAST = RAMPOOL-1    ; save memory location of rightmost 7S-LED digit
+
 
 ;       7-seg LED patterns, "70s chique"
 PAT7SM9:
@@ -178,6 +189,20 @@ PUT7S:
         CALL    AFLAGS
         LD      LED7LAST,A
         .endif
-
         RET
+
+        .macro  Board_IO_Init
+        .if     gt,(HAS_LED7SEG-1)
+        MOV     LED7GROUP,#0     ; one of position HAS_LED7SEG 7-SEG digit groups
+        .endif
+        MOV     LED7FIRST  ,#0x66 ; 7S LEDs 4..
+        MOV     LED7FIRST+1,#0x78 ; 7S LEDs .t.
+        MOV     LED7FIRST+2,#0x74 ; 7S LEDs ..h
+        .endm
+
+        .else
+        .macro  Board_IO_Init
+        ; no LED-7Seg
+        .endm
+
         .endif

--- a/inc/defconf.inc
+++ b/inc/defconf.inc
@@ -7,7 +7,7 @@
 
         TERM_LINUX       = 1    ; LF terminates line
 
-        HALF_DUPLEX      = 0    ; Use UART in half duplex mode
+        HALF_DUPLEX      = 0    ; Use UART in half duplex mode (1: PD5, 2: PA3)
         HAS_RXUART       = 1    ; Enable UART RXD, word ?RX
         HAS_TXUART       = 1    ; Enable UART TXD, word TX!
         HAS_RXSIM        = 0    ; Enable RxD via GPIO/TIM4, word ?RXGP

--- a/inc/stm8device.inc
+++ b/inc/stm8device.inc
@@ -21,8 +21,28 @@
 
 ; ***** Option Bytes in EEPROM
 
+        OPT0         = 0x4800   ; Read-out protection                   (0x00)
+        OPT1         = 0x4801   ; User Boot Code (UBC)                  (0x00)
+        NOPT1        = 0x4802   ;                                       (0xFF)
         OPT2         = 0x4803   ; Alternate Function Mapping            (0x00)
-        NOPT2        = 0x4804   ; Alternate Function Mapping            (0xFF)
+        NOPT2        = 0x4804   ;                                       (0xFF)
+        OPT3         = 0x4805   ; Watchdog option                       (0x00)
+        NOPT3        = 0x4806   ;                                       (0xFF)
+        OPT4         = 0x4807   ; Clock option                          (0x00)
+        NOPT4        = 0x4808   ;                                       (0xFF)
+        OPT5         = 0x4809   ; HSE Clock startup                     (0x00)
+        NOPT5        = 0x480A   ;                                       (0xFF)
+        OPT6         = 0x480B   ; TMU (Reserved)                        (0x00)
+        NOPT6        = 0x480C   ;                                       (0xFF)
+        OPT7         = 0x480D   ; Alternate Function Mapping            (0x00)
+        NOPT7        = 0x480E   ;                                       (0xFF)
+
+;       OPT8         = 0x4810   ; TMU_KEY 1
+;       ...
+;       OPT16        = 0x4818   ; TMU_KEY 8
+
+        OPTBL        = 0x487E   ; Bootloader                            (0x00)
+        NOPTBL       = 0x487F   ;                                       (0xFF)
 
 ; ***** Port A
 

--- a/mcu/STM8S103.efr
+++ b/mcu/STM8S103.efr
@@ -52,13 +52,13 @@
 \ 807A
 \ 807E
 
-                 \ Register name                      \ Reset status
-4800 equ OPT0    \ Options 0
-4801 equ OPT1    \ Options 1
-4803 equ OPT2    \ Options 2
-4805 equ OPT3    \ Options 3
-4807 equ OPT4    \ Options 4
-4809 equ OPT5    \ Options 5
+                 \ Register name
+4800 equ OPT0    \ Options 0 Read-out protection
+4801 equ OPT1    \ Options 1 User boot code
+4803 equ OPT2    \ Options 2 Alternate function remapping
+4805 equ OPT3    \ Options 3 Misc. option
+4807 equ OPT4    \ Options 4 Clock option
+4809 equ OPT5    \ Options 5 HSE clock startup
 
                  \ Register name                      \ Reset status
 5000 equ PA_ODR  \ Port A data output latch register         0x00

--- a/mcu/STM8S105.efr
+++ b/mcu/STM8S105.efr
@@ -52,13 +52,16 @@
 \ 807A
 \ 807E
 
-                 \ Register name                      \ Reset status
-4800 equ OPT0    \ Options 0
-4801 equ OPT1    \ Options 1
-4803 equ OPT2    \ Options 2
-4805 equ OPT3    \ Options 3
-4807 equ OPT4    \ Options 4
-4809 equ OPT5    \ Options 5
+                 \ Register name
+4800 equ OPT0    \ Options 0 Read-out protection
+4801 equ OPT1    \ Options 1 User boot code
+4803 equ OPT2    \ Options 2 Alternate function remapping
+4805 equ OPT3    \ Options 3 Watchdog option
+4807 equ OPT4    \ Options 4 Clock option
+4809 equ OPT5    \ Options 5 HSE clock startup
+480B equ OPT6    \ Options 6 TMU (reserved)
+480D equ OPT7    \ Options 7 (Flash wait states)
+487E equ OPTBL   \ Options Bootloader
 
                  \ Register name                      \ Reset status
 5000 equ PA_ODR  \ Port A data output latch register         0x00

--- a/mcu/STM8S207.efr
+++ b/mcu/STM8S207.efr
@@ -52,13 +52,16 @@
 \ 807A
 \ 807E
 
-                 \ Register name                      \ Reset status
-4800 equ OPT0    \ Options 0
-4801 equ OPT1    \ Options 1
-4803 equ OPT2    \ Options 2
-4805 equ OPT3    \ Options 3
-4807 equ OPT4    \ Options 4
-4809 equ OPT5    \ Options 5
+                 \ Register name
+4800 equ OPT0    \ Options 0 Read-out protection
+4801 equ OPT1    \ Options 1 User boot code
+4803 equ OPT2    \ Options 2 Alternate function remapping
+4805 equ OPT3    \ Options 3 Watchdog option
+4807 equ OPT4    \ Options 4 Clock option
+4809 equ OPT5    \ Options 5 HSE clock startup
+480B equ OPT6    \ Options 6 TMU (reserved)
+480D equ OPT7    \ Options 7 Flash wait states
+487E equ OPTBL   \ Options Bootloader
 
                  \ Register name                      \ Reset status
 5000 equ PA_ODR  \ Port A data output latch register         0x00

--- a/tools/genconst.awk
+++ b/tools/genconst.awk
@@ -21,18 +21,21 @@ $1~/^00/ && $3!~/(LINK|RAMPOOL)/ && $4~/[=;]/ && $7~/^"/ {
   next
 }
 
-# extract lines like:
-# RamWord USREVAL         ; "'EVAL" execution vector of EVAL
-preLine~/RamWord/ && $3!~/RAMPOOL/ && $4=="=" && $5~/RAMPOOL/ {
+# use case 1:
+#         RamWord USREVAL         ; "'EVAL" execution vector of EVAL
+# use case 2:
+#         RamByte LED7GROUP       ; byte index of 7-SEG digit group
+preLine~/Ram(Word|Byte|Blck)/ && $3!~/RAMPOOL/ && $4=="=" && $5~/RAMPOOL/ {
   if (split(preLine,b,"\"") == 3) {
-    symbol = b[2]
+    symbol = b[2]           # use case 1
+    comment = " \\ " b[3]
   }
   else {
-    symbol = $3
+    symbol = $3             # use case 2
+    split(preLine,a,";");
+    addr = "$" substr($1,3)
+    comment = " \\ " a[2]
   }
-  split(preLine,a,";");
-  addr = "$" substr($1,3)
-  comment = " \\ " a[2]
   print  addr " CONSTANT " symbol comment > target symbol
   next
 }


### PR DESCRIPTION
Some of the re-work has been done but it's still not clear how to distribute init snippets in the most transparent way. The current approach tries to identify generic settings and confine them to generic init code (e.g. UART, 7S-LED buffers, etc) and keep board specific settings in `globcon.inc` and `boardcore.inc`.