### PR TITLE
Update defconf.inc

### DIFF
--- a/inc/defconf.inc
+++ b/inc/defconf.inc
@@ -3,7 +3,7 @@
 ;       Default settings for all options
 ;--------------------------------------------------------
         RELVER1          = 2    ; Revision digit 1
-        RELVER0          = 10   ; Revision digit 0
+        RELVER0          = 9   ; Revision digit 0
         PRE_REL          = 1    ; Pre Release digit 0 (0: release)
 
         TERM_LINUX       = 1    ; LF terminates line


### PR DESCRIPTION
This release is advertised as 2.2.9
10 has two digits, it can't be assigned to a single digit.